### PR TITLE
Add legacy controllers endpoints for the existing Vue app to function

### DIFF
--- a/app/controllers/api/everything_controller.rb
+++ b/app/controllers/api/everything_controller.rb
@@ -1,0 +1,8 @@
+class Api::EverythingController < ApiController
+  def show
+    @hydrants = Hydrant.kept
+    @hydrant_checks = HydrantCheck.kept
+    @pump_operators = PumpOperator.kept
+    @apparatus = Apparatus.kept
+  end
+end

--- a/app/controllers/api/hydrant_checks_controller.rb
+++ b/app/controllers/api/hydrant_checks_controller.rb
@@ -1,0 +1,42 @@
+class Api::HydrantChecksController < ApiController
+  def create
+    @hydrant_check = hydrant.hydrant_checks.build(create_params)
+
+    if @hydrant_check.save && true # TODO: make auto-approval a configurable setting
+      @hydrant_check.approve!
+    end
+
+    render status: (@hydrant_check.persisted? ? 200 : 422)
+  end
+
+  private
+
+  def format_errors(check)
+    check.errors.reduce({}) do |hash, error_pair|
+      hash[error_pair[0].to_s.camelize(:lower)] = error_pair[1]
+      hash
+    end
+  end
+
+  def create_params
+    params.require(:hydrant_check).permit(
+      :vegetation_overgrown,
+      :tank_locked,
+      :lock_operable,
+      :prime_pulled,
+      :circulated,
+      :line_used,
+      :minutes_pumped,
+      :in_service,
+      :notes,
+      :pump_operator_id,
+      :apparatus_id,
+      :needs_follow_up
+    )
+  end
+
+  def hydrant
+    Hydrant.find(params[:hydrant_id])
+  end
+  helper_method :hydrant
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,13 @@
+class ApiController < ApplicationController
+
+  skip_before_action :verify_authenticity_token
+  before_action :ignore_non_json
+
+  private
+
+  def ignore_non_json
+    return if request.format.to_s.match(/json/)
+
+    head 404, "content_type": "text/plain"
+  end
+end

--- a/app/models/apparatus.rb
+++ b/app/models/apparatus.rb
@@ -4,8 +4,6 @@ class Apparatus < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { scope: [:deleted_at] }
 
-  default_scope { where(deleted_at: nil) }
-
   has_many :hydrant_checks
 
   def to_param

--- a/app/models/concerns/hydrants_display.rb
+++ b/app/models/concerns/hydrants_display.rb
@@ -1,0 +1,37 @@
+module HydrantsDisplay
+  extend ActiveSupport::Concern
+
+  # TODO: remove this
+  included do
+    def display_icon
+      if muni?
+        "images/icons/marker--muni-hydrant.png"
+      elsif out_of_service?
+        "images/icons/marker--out-of-service.png"
+      elsif needs_follow_up? || needs_testing?
+        "images/icons/marker--needs-testing.png"
+      else
+        "images/icons/marker--in-service.png"
+      end
+    end
+
+    def gmaps_position
+      "#{latitude},#{longitude}"
+    end
+
+    def status_css_class
+      if hydrant_checks.blank?
+        "gray-5"
+      elsif out_of_service?
+        "red-5"
+      elsif needs_testing?
+        "yellow-5"
+      else
+        "green-5"
+      end
+    end
+  end
+
+  class_methods do
+  end
+end

--- a/app/models/hydrant.rb
+++ b/app/models/hydrant.rb
@@ -1,4 +1,5 @@
 class Hydrant < ApplicationRecord
+  include HydrantsDisplay
   include Discard::Model
   self.discard_column = :deleted_at
 

--- a/app/models/hydrant_check.rb
+++ b/app/models/hydrant_check.rb
@@ -22,4 +22,14 @@ class HydrantCheck < ApplicationRecord
   validates :notes, presence: true, unless: -> { in_service && !needs_follow_up }
   validates :pump_operator_id, presence: true
   validates :apparatus_id, presence: true
+
+  def approve!
+    touch(:approved_at)
+
+    if needs_follow_up
+      hydrant.update(last_check_note: notes, needs_follow_up: 1.week.from_now, in_service: in_service) # default to 1 week
+    else
+      hydrant.update(last_check_note: notes, last_tested_at: created_at, in_service: in_service, needs_follow_up: nil)
+    end
+  end
 end

--- a/app/models/pump_operator.rb
+++ b/app/models/pump_operator.rb
@@ -5,8 +5,6 @@ class PumpOperator < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: [:deleted_at] }
   validates :email_address, uniqueness: { allow_nil: true, allow_blank: true, scope: [:deleted_at] }
 
-  self.default_scope { where(deleted_at: nil) }
-
   has_many :hydrant_checks
 
   def to_param

--- a/app/views/api/everything/show.json.jbuilder
+++ b/app/views/api/everything/show.json.jbuilder
@@ -1,0 +1,21 @@
+json.hydrants(@hydrants) do |hydrant|
+  json.(hydrant, :id, :name, :hydrant_type, :staff_notes, :last_check_note, :needs_follow_up)
+  json.position do
+    json.lat hydrant.latitude
+    json.lng hydrant.longitude
+  end
+  json.tank_capacity hydrant.tank_capacity if hydrant.tank?
+  json.last_tested_at  hydrant.last_tested_at&.in_time_zone("Eastern Time (US & Canada)")
+  json.out_of_service hydrant.out_of_service?
+  json.needs_testing hydrant.needs_testing?
+  json.icon hydrant.display_icon
+end
+json.hydrant_checks @hydrant_checks do |hydrant_check|
+  json.partial! 'api/hydrant_checks/show', hydrant_check: hydrant_check
+end
+json.pump_operators(@pump_operators) do |pump_operator|
+  json.(pump_operator, :id, :name, :email_address, :phone_number)
+end
+json.apparatus(@apparatus) do |apparatus|
+  json.(apparatus, :id, :name)
+end

--- a/app/views/api/hydrant_checks/_show.json.jbuilder
+++ b/app/views/api/hydrant_checks/_show.json.jbuilder
@@ -1,0 +1,1 @@
+json.(hydrant_check, :id, :hydrant_id, :vegetation_overgrown, :tank_locked, :lock_operable, :prime_pulled, :circulated, :line_used, :minutes_pumped, :in_service, :notes, :approved_at, :created_at, :updated_at, :pump_operator_id, :apparatus_id, :needs_follow_up)

--- a/app/views/api/hydrant_checks/create.json.jbuilder
+++ b/app/views/api/hydrant_checks/create.json.jbuilder
@@ -1,0 +1,14 @@
+if @hydrant_check.persisted?
+  json.status "ok"
+  json.hydrant_check do
+    json.(@hydrant_check, :id, :hydrant_id, :vegetation_overgrown, :tank_locked, :lock_operable, :prime_pulled, :circulated, :line_used, :minutes_pumped, :in_service, :notes, :approved_at, :created_at, :updated_at, :pump_operator_id, :apparatus_id, :needs_follow_up)
+  end
+  json.flash do
+    json.success "Hydrant updated!"
+  end
+else
+  json.status "error"
+  json.flash do
+    json.error @hydrant_check.errors.full_messages.join(", ")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
 
+  namespace :api do
+    resource :everything, only: %i(show), controller: "everything"
+  end
+
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   #
   root to: "landing#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     resource :everything, only: %i(show), controller: "everything"
+    resources :hydrant_checks, only: %i(create)
   end
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/spec/requests/api/everything_request_spec.rb
+++ b/spec/requests/api/everything_request_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Everythings", type: :request do
+
+  before do
+    3.times { FactoryBot.create(:pump_operator) }
+    3.times { FactoryBot.create(:apparatus) }
+    3.times { FactoryBot.create(:hydrant, hydrant_type: %w(dry wet tank).sample) }
+    Hydrant.all.each do |hydrant|
+      3.times do
+        FactoryBot.create(
+          :hydrant_check,
+          hydrant: hydrant,
+          pump_operator: PumpOperator.all.sample,
+          apparatus: Apparatus.all.sample
+        )
+      end
+    end
+  end
+
+  describe "GET /show" do
+    it "returns everything — all hydrants, checks, apparatus, and pump operators" do
+      get "/api/everything", as: :json
+      json = JSON.parse(response.body)
+      expect(json["pump_operators"].length).to eq 3
+      expect(json["apparatus"].length).to eq 3
+      expect(json["hydrants"].length).to eq 3
+      expect(json["hydrant_checks"].length).to eq 9
+    end
+
+    it "excludes discarded records" do
+      [PumpOperator, Apparatus, Hydrant, HydrantCheck].each { |klass| klass.all.sample.discard! }
+
+      get "/api/everything", as: :json
+      json = JSON.parse(response.body)
+      expect(json["pump_operators"].length).to eq 2
+      expect(json["apparatus"].length).to eq 2
+      expect(json["hydrants"].length).to eq 2
+      expect(json["hydrant_checks"].length).to eq 8
+    end
+  end
+end

--- a/spec/requests/api/hydrant_checks_request_spec.rb
+++ b/spec/requests/api/hydrant_checks_request_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe "Api::HydrantChecks", type: :request do
+
+  before do
+    @hydrant = FactoryBot.create(:hydrant)
+    @pump_operator = FactoryBot.create(:pump_operator)
+    @apparatus = FactoryBot.create(:apparatus)
+  end
+
+  describe "POST /create" do
+    it "saves with good params" do
+      post "/api/hydrant_checks", params: { hydrant_id: @hydrant.id, hydrant_check: check_params }, as: :json
+
+      json = JSON.parse(response.body)
+      expect(json["status"]).to eq "ok"
+      expect(json["hydrant_check"]["hydrant_id"]).to eq @hydrant.id
+      expect(response.content_type).to eq "application/json; charset=utf-8"
+      expect(response).to have_http_status(200)
+    end
+
+    it "does not save with bad params" do
+      post "/api/hydrant_checks", params: { hydrant_id: @hydrant.id, hydrant_check: check_params.except(:apparatus_id) }, as: :json
+
+      json = JSON.parse(response.body)
+      expect(json["status"]).to eq "error"
+      expect(json["flash"]["error"]).to eq "Apparatus must exist, Apparatus can't be blank"
+      expect(response.content_type).to eq "application/json; charset=utf-8"
+      expect(response).to have_http_status(422)
+    end
+  end
+
+  def check_params
+    {
+      "tank_locked":true,
+      "vegetation_overgrown":true,
+      "lock_operable":true,
+      "prime_pulled":true,
+      "circulated":true,
+      "line_used":"3",
+      "minutes_pumped":5,
+      "in_service":true,
+      "notes":"yup",
+      "pump_operator_id": @pump_operator.id,
+      "apparatus_id": @apparatus.id,
+      "needs_follow_up":true
+    }
+  end
+end


### PR DESCRIPTION
Adding these to this new application to provide support for the existing Vue SPA that's driving the UI. Since I'll be bringing the UI back to the monolith 🙌🏻 these can be removed once the necessary feature set is recreated.